### PR TITLE
Connection fix

### DIFF
--- a/v2.0.1/Opentracker2 Examples/Opentracker_2_0_1/gsm.ino
+++ b/v2.0.1/Opentracker2 Examples/Opentracker_2_0_1/gsm.ino
@@ -382,7 +382,7 @@
           delay(4000);  //might take sometime to open socket
           gsm_get_reply();
           
-          char *tmp = strstr(modem_reply, "CONNECT OK");      
+          char *tmp = strstr(modem_reply, "CONNECT");      
           if(tmp!=NULL)
             {           
                 debug_print(F("Connected to remote server: "));


### PR DESCRIPTION
The openTracker couldn't connect. After debugging I found that the gsm module was only responding with CONNECT instead of CONNECT OK. Removing the OK would also work I assume