### PR TITLE
Fix compiling issue with WDT_Disable

### DIFF
--- a/v2.0.1/Opentracker_2_0_1/Opentracker_2_0_1.ino
+++ b/v2.0.1/Opentracker_2_0_1/Opentracker_2_0_1.ino
@@ -71,7 +71,7 @@ void setup() {
 	
 	// remember that watchdog is enabled by default, calling WDT_Disable() here will disable it. If you comment out WDT_Disable(), 
 	// your code should call WDT_Restart() before the default timeout is reached (16s).
-	WDT_Disable();
+	WDT_Disable(WDT);
 
 	// use the following code to change the watchdog default timeout (16s). Set wdp_ms as follows: {your intended timeout} * 256
 	//uint32_t wdp_ms = 4096;


### PR DESCRIPTION
This is an fix for an compiling error, below is the error message

Arduino: 1.5.8 (Windows 8), Board: "Arduino Due OpenTracker (Native USB Port)"

Opentracker_2_0_1.ino: In function 'void setup()':
Opentracker_2_0_1.ino:74:14: error: too few arguments to function 'void WDT_Disable(Wdt)'
In file included from C:\Program Files (x86)\Arduino\hardware\arduino\sam\system/libsam/chip.h:63:0,
from C:\Program Files (x86)\Arduino\hardware\arduino\sam\cores\arduino/Arduino.h:42,
from C:\Users\Anand\Documents\Arduino\libraries\TinyGPS/TinyGPS.h:28,
from Opentracker_2_0_1.ino:6:
C:\Program Files (x86)\Arduino\hardware\arduino\sam\system/libsam/include/wdt.h:61:13: note: declared here
extern void WDT_Disable( Wdt pWDT ) ;
^
Error compiling.